### PR TITLE
Fix translation language detection

### DIFF
--- a/src/main/kotlin/us/xylight/neptune/Logger.kt
+++ b/src/main/kotlin/us/xylight/neptune/Logger.kt
@@ -2,12 +2,12 @@ package us.xylight.neptune
 
 import us.xylight.neptune.util.Color
 
-enum class LogLevel(val priority: Int, val color: String) {
-    ERROR(1, Color.RED_BRIGHT),
-    WARNING(2, Color.YELLOW),
-    INFO(3, Color.BLUE),
-    VERBOSE(4, Color.BLUE_BRIGHT),
-    DEBUG(5, Color.GREEN)
+enum class LogLevel(val idColor: String, val textColor: String) {
+    ERROR(Color.RED_BOLD_BRIGHT, Color.RED_BRIGHT),
+    WARNING(Color.YELLOW_BOLD_BRIGHT, Color.YELLOW_BRIGHT),
+    INFO(Color.BLUE_BOLD, Color.BLUE),
+    VERBOSE(Color.BLUE_BOLD_BRIGHT, Color.BLUE_BRIGHT),
+    DEBUG(Color.GREEN_BOLD_BRIGHT, Color.GREEN_BRIGHT)
 }
 
 object Logger {
@@ -15,8 +15,8 @@ object Logger {
     var logLevel = LogLevel.VERBOSE
 
     fun log(message: String, level: LogLevel) {
-        if (level.priority <= logLevel.priority) {
-            println("${level.color} [${level.name}] $message ${Color.RESET}")
+        if (level.ordinal <= logLevel.ordinal) {
+            println("[${level.idColor}${level.name}${Color.RESET}] ${level.textColor}$message${Color.RESET}")
         }
     }
 }

--- a/src/main/kotlin/us/xylight/neptune/command/roles/Roles.kt
+++ b/src/main/kotlin/us/xylight/neptune/command/roles/Roles.kt
@@ -4,6 +4,8 @@ import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.events.interaction.component.StringSelectInteractionEvent
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
+import us.xylight.neptune.LogLevel
+import us.xylight.neptune.Logger
 import us.xylight.neptune.command.Command
 import us.xylight.neptune.command.RatelimitedCommand
 import us.xylight.neptune.command.Subcommand
@@ -40,6 +42,8 @@ object Roles : RatelimitedCommand {
                     0xff0f0f
                 ).build()
             ).queue()
+
+            Logger.log("Missing role selector | ${interaction.guild?.name} | $id", LogLevel.WARNING)
 
             return
         }

--- a/src/main/kotlin/us/xylight/neptune/command/translate/Translate.kt
+++ b/src/main/kotlin/us/xylight/neptune/command/translate/Translate.kt
@@ -101,7 +101,7 @@ object Translate : RatelimitedCommand {
         embed
             .addField("Input", text.asString, false)
             .addField("Translated", translation.translatedText, false)
-            .setFooter("${langNames[translation.detectedLanguage?.code?.lowercase()]} to ${langNames[lang.asString]}")
+            .setFooter("${langNames[translation.detectedLanguage?.code?.lowercase()] ?: "\uD83C\uDFF3️ Unknown"} to ${langNames[lang.asString]}")
 
         Logger.log("Translation | From: ${translation.detectedLanguage} | To: ${lang.asString} | Text: ${translation.translatedText}", LogLevel.VERBOSE)
 
@@ -126,7 +126,7 @@ object Translate : RatelimitedCommand {
             EmbedUtil.simpleEmbed("Translation", "")
                 .addField("Input", text, false)
                 .addField("Translated", translation.translatedText, false)
-                .setFooter("${langNames[translation.detectedLanguage?.code?.lowercase()]} to ${langNames[lang]} • Called by ${user.name}")
+                .setFooter("${langNames[translation.detectedLanguage?.code?.lowercase()] ?: "\uD83C\uDFF3️ Unknown"} to ${langNames[lang]} • Called by ${user.name}")
 
         reply.editMessageEmbeds(
             embed.build()


### PR DESCRIPTION
Language autodetection was weird, and showed "null" if DeepL could not accurately detect the language. This has been replaced by an "Unknown" flag.