### PR TITLE
Fix 'interaction failed' when editing wrong role picker

### DIFF
--- a/src/main/kotlin/us/xylight/neptune/command/roles/Add.kt
+++ b/src/main/kotlin/us/xylight/neptune/command/roles/Add.kt
@@ -44,7 +44,14 @@ object Add : Subcommand {
             return
         }
 
-        if (selection.guildId != interaction.guild!!.idLong) return
+        if (selection.guildId != interaction.guild!!.idLong) {
+
+            interaction.reply("")
+                .setEmbeds(EmbedUtil.simpleEmbed("Error", "The role picker of that ID does not belong to this guild.", 0xff0f0f).build())
+                .queue()
+
+            return
+        }
 
         selection.roles.add(Role(role.idLong, label, description, emoji))
 

--- a/src/main/kotlin/us/xylight/neptune/command/roles/Delete.kt
+++ b/src/main/kotlin/us/xylight/neptune/command/roles/Delete.kt
@@ -28,7 +28,14 @@ object Delete : Subcommand {
             return
         }
 
-        if (selection.guildId != interaction.guild!!.idLong) return
+        if (selection.guildId != interaction.guild!!.idLong) {
+
+            interaction.reply("")
+                .setEmbeds(EmbedUtil.simpleEmbed("Error", "The role picker of that ID does not belong to this guild.", 0xff0f0f).build())
+                .queue()
+
+            return
+        }
 
         DatabaseHandler.deleteRoleSelection(selection.id)
         (interaction.guild!!.getGuildChannelById(selection.channelId) as TextChannel).deleteMessageById(

--- a/src/main/kotlin/us/xylight/neptune/command/roles/DeleteItem.kt
+++ b/src/main/kotlin/us/xylight/neptune/command/roles/DeleteItem.kt
@@ -39,7 +39,14 @@ object DeleteItem : Subcommand {
             return
         }
 
-        if (selection.guildId != interaction.guild!!.idLong) return
+        if (selection.guildId != interaction.guild!!.idLong) {
+
+            interaction.reply("")
+                .setEmbeds(EmbedUtil.simpleEmbed("Error", "The role picker of that ID does not belong to this guild.", 0xff0f0f).build())
+                .queue()
+
+            return
+        }
 
         selection.roles.removeAt(index - 1)
 

--- a/src/main/kotlin/us/xylight/neptune/command/roles/Edit.kt
+++ b/src/main/kotlin/us/xylight/neptune/command/roles/Edit.kt
@@ -38,7 +38,14 @@ object Edit : Subcommand {
             selection.unassigned = unassigned.idLong
         }
 
-        if (selection.guildId != interaction.guild!!.idLong) return
+        if (selection.guildId != interaction.guild!!.idLong) {
+
+            interaction.reply("")
+                .setEmbeds(EmbedUtil.simpleEmbed("Error", "The role picker of that ID does not belong to this guild.", 0xff0f0f).build())
+                .queue()
+
+            return
+        }
 
         (interaction.guild!!.getGuildChannelById(selection.channelId) as TextChannel).editMessageEmbedsById(
             selection.msgId,


### PR DESCRIPTION
Responds with an error message instead of just failing.